### PR TITLE
Version 1.2.11

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,24 @@
 
 --------
 
+## Version 1.2.11
+
+### Minor updates - 1.2.11
+
+- None
+
+### Release updates - 1.2.11
+
+- (MAIN) Allowing to replace the colors by setting the variables before running the script (colorblind)
+- (README) explaining the new '-d' option for the help
+- (SCC) Adding the SecurityContextContraints data in the script
+- (POD) Including the PodDisruptionBudget details.
+- (MAIN) Avoiding content variables to be query twice.
+- (MAIN) Replacing all Shell variables in JQ command by args
+- (MAIN) Substituing '\n' characters in jq messages.
+
+--------
+
 ## Version 1.2.10
 
 ### Minor updates - 1.2.10

--- a/README.md
+++ b/README.md
@@ -60,10 +60,11 @@ mg_check
 
 #### Script Options
 
-using the `-h` option will display the help and provide the list of the available options, and the version of the script.
+Using the `-h` option will display the help and provide the list of the available options, and the version of the script.
+Adding the `-d` option with the `-h` option will display the customizable variables (including colors for colorblind persons)
 
 ```text
-usage: mg_cluster_status.sh [-acevMmnops] [-d] [-h]
+usage: mg_cluster_status.sh [-acevMmnopsS] [-d] [-h]
 |---------------------------------------------------------------------------------------|
 | Options | Description                                                     | [Details] |
 |---------|-----------------------------------------------------------------|-----------|
@@ -77,6 +78,7 @@ usage: mg_cluster_status.sh [-acevMmnops] [-d] [-h]
 |      -o | display the OPERATORS status                                    | [Y]       |
 |      -p | display the PODS status                                         | [Y]       |
 |      -s | display the STATIC PODs status                                  | [Y]       |
+|      -S | display the SecurityContextConstraints                          | [Y]       |
 |---------|-----------------------------------------------------------------|-----------|
 |         | Additional Options:                                             |           |
 |---------|-----------------------------------------------------------------|-----------|
@@ -94,6 +96,15 @@ Customizable variables before running the script (Optional):
 |export POD_TRUNK=<interger         | #Change the length of the POD Message in 'oc get co'                             | [100]      |           |
 |export MIN_RESTART=<integer>       | #Change the minimal number of restart when checking the POD restarts             | [10]       |           |
 |export TAIL_LOG=<integer>          | #Change the number of lines displayed from logs ('tail')                         | [15]       |           |
+|export graytext=<color_code>       | #Replace the gray color used in the script                                       | [\x1B[30m] |           |
+|export redtext=<color_code>        | #Replace the red color used in the script                                        | [\x1B[31m] |           |
+|export greentext=<color_code>      | #Replace the green color used in the script                                      | [\x1B[32m] |           |
+|export yellowtext=<color_code>     | #Replace the yellow color used in the script                                     | [\x1B[33m] |           |
+|export bluetext=<color_code>       | #Replace the blue color used in the script                                       | [\x1B[34m] |           |
+|export purpletext=<color_code>     | #Replace the purple color used in the script                                     | [\x1B[35m] |           |
+|export cyantext=<color_code>       | #Replace the cyan color used in the script                                       | [\x1B[36m] |           |
+|export whitetext=<color_code>      | #Replace the white color used in the script                                      | [\x1B[37m] |           |
+|export resetcolor=<color_code>     | #Replace the color used to rest colors in the script                             | [\x1B[0m]  |           |
 |-----------------------------------------------------------------------------------------------------------------------------------------------|
 
 Current Version:  1.X.X - The script is up-to-date. Thanks

--- a/mg_cluster_status.sh
+++ b/mg_cluster_status.sh
@@ -2,7 +2,7 @@
 ##################################################################
 # Script       # mg_cluster_status.sh
 # Description  # Display basic health check on a Must-gather
-# @VERSION     # 1.2.10
+# @VERSION     # 1.2.11
 ##################################################################
 # Changelog.md # List the modifications in the script.
 # README.md    # Describes the repository usage
@@ -15,7 +15,7 @@ fct_help(){
   then
     ScriptName=$(basename $0)
   fi
-  echo -e "usage: ${cyantext}${ScriptName} [-acevMmnops] ${purpletext}[-d] [-h]${resetcolor}"
+  echo -e "usage: ${cyantext}${ScriptName} [-acevMmnopsS] ${purpletext}[-d] [-h]${resetcolor}"
   OPTION_TAB=8
   DESCR_TAB=63
   DETAILS_TAB=10
@@ -32,37 +32,52 @@ fct_help(){
   printf "|${cyantext}%${OPTION_TAB}s${resetcolor} | %-${DESCR_TAB}s | ${greentext}%-${DETAILS_TAB}s${resetcolor}|\n" "-o" "display the OPERATORS status" "[Y]"
   printf "|${cyantext}%${OPTION_TAB}s${resetcolor} | %-${DESCR_TAB}s | ${greentext}%-${DETAILS_TAB}s${resetcolor}|\n" "-p" "display the PODS status" "[Y]"
   printf "|${cyantext}%${OPTION_TAB}s${resetcolor} | %-${DESCR_TAB}s | ${greentext}%-${DETAILS_TAB}s${resetcolor}|\n" "-s" "display the STATIC PODs status" "[Y]"
+  printf "|${cyantext}%${OPTION_TAB}s${resetcolor} | %-${DESCR_TAB}s | ${greentext}%-${DETAILS_TAB}s${resetcolor}|\n" "-S" "display the SecurityContextConstraints" "[Y]"
   printf "|%${OPTION_TAB}s-|-%-${DESCR_TAB}s-|-%-${DETAILS_TAB}s|\n" |tr \  '-'
   printf "|%${OPTION_TAB}s | %-${DESCR_TAB}s | %-${DETAILS_TAB}s|\n" "" "Additional Options:" ""
   printf "|%${OPTION_TAB}s-|-%-${DESCR_TAB}s-|-%-${DETAILS_TAB}s|\n" |tr \  '-'
   printf "|${purpletext}%${OPTION_TAB}s${resetcolor} | %-${DESCR_TAB}s | %-${DETAILS_TAB}s|\n" "-d" "display additional details on specific Options (as noted above)" ""
   printf "|${purpletext}%${OPTION_TAB}s${resetcolor} | %-${DESCR_TAB}s | %-${DETAILS_TAB}s|\n" "-h" "display this help and check for updated version" ""
   printf "|%${OPTION_TAB}s---%-${DESCR_TAB}s---%-${DETAILS_TAB}s|\n" |tr \  '-'
-  echo -e "\nCustomizable variables before running the script (Optional):"
-  EXPORT_TAB=34
-  COMMENT_TAB=80
-  DEFAULT_TAB=10
-  CURRENT_TAB=10
-  if [[ ! -z ${OC} ]]
-  then
-    OC_LENGTH=$(echo "[${OC}]" | wc -c | awk '{print $1}')
-    if [[ ${OC_LENGTH} -gt ${CURRENT_TAB} ]]
-    then
-      CURRENT_TAB=${OC_LENGTH}
-    fi
-  fi
 
-  printf "|%-${EXPORT_TAB}s---%-${COMMENT_TAB}s---%-${DEFAULT_TAB}s---%-${CURRENT_TAB}s|\n" |tr \  '-'
-  printf "|%-${EXPORT_TAB}s | %-${COMMENT_TAB}s | %-${DEFAULT_TAB}s | %-${CURRENT_TAB}s|\n" "Options" "Description" "[Default]" "[Current]"
-  printf "|%-${EXPORT_TAB}s-|-%-${COMMENT_TAB}s-|-%-${DEFAULT_TAB}s-|-%-${CURRENT_TAB}s|\n" |tr \  '-'
-  printf "|${purpletext}%-${EXPORT_TAB}s${resetcolor} | %-${COMMENT_TAB}s | ${greentext}%-${DEFAULT_TAB}s${resetcolor} | ${redtext}%-${CURRENT_TAB}s${resetcolor}|\n" "export OC=[omc|omg|oc]" "#Change the must-gather tool (use 'oc' to run the script against live cluster)" "[${DEFAULT_OC}]" "$(if [[ ! -z ${OC} ]] && [[ ${OC} != ${DEFAULT_OC} ]]; then echo "[${OC}]"; fi)"
-  printf "|${purpletext}%-${EXPORT_TAB}s${resetcolor} | %-${COMMENT_TAB}s | ${greentext}%-${DEFAULT_TAB}s${resetcolor} | ${redtext}%-${CURRENT_TAB}s${resetcolor}|\n" "export ALERT_TRUNK=<interger>" "#Change the length of the Alert Descriptions" "[${DEFAULT_TRUNK}]" "$(if [[ ! -z ${ALERT_TRUNK} ]] && [[ ${ALERT_TRUNK} != ${DEFAULT_TRUNK} ]]; then echo "[${ALERT_TRUNK}]"; fi)"
-  printf "|${purpletext}%-${EXPORT_TAB}s${resetcolor} | %-${COMMENT_TAB}s | ${greentext}%-${DEFAULT_TAB}s${resetcolor} | ${redtext}%-${CURRENT_TAB}s${resetcolor}|\n" "export CONDITION_TRUNK=<interger" "#Change the length of the Operator Message in 'oc get co'" "[${DEFAULT_CONDITION_TRUNK}]" "$(if [[ ! -z ${CONDITION_TRUNK} ]] && [[ ${CONDITION_TRUNK} != ${DEFAULT_CONDITION_TRUNK} ]]; then echo "[${CONDITION_TRUNK}]"; fi)"
-  printf "|${purpletext}%-${EXPORT_TAB}s${resetcolor} | %-${COMMENT_TAB}s | ${greentext}%-${DEFAULT_TAB}s${resetcolor} | ${redtext}%-${CURRENT_TAB}s${resetcolor}|\n" "export POD_TRUNK=<interger" "#Change the length of the POD Message in 'oc get co'" "[${DEFAULT_TRUNK}]" "$(if [[ ! -z ${POD_TRUNK} ]] && [[ ${POD_TRUNK} != ${DEFAULT_TRUNK} ]]; then echo "[${POD_TRUNK}]"; fi)"
-  printf "|${purpletext}%-${EXPORT_TAB}s${resetcolor} | %-${COMMENT_TAB}s | ${greentext}%-${DEFAULT_TAB}s${resetcolor} | ${redtext}%-${CURRENT_TAB}s${resetcolor}|\n" "export MIN_RESTART=<integer>" "#Change the minimal number of restart when checking the POD restarts" "[${DEFAULT_MIN_RESTART}]" "$(if [[ ! -z ${MIN_RESTART} ]] && [[ ${MIN_RESTART} != ${DEFAULT_MIN_RESTART} ]]; then echo "[${MIN_RESTART}]"; fi)"
-  printf "|${purpletext}%-${EXPORT_TAB}s${resetcolor} | %-${COMMENT_TAB}s | ${greentext}%-${DEFAULT_TAB}s${resetcolor} | ${redtext}%-${CURRENT_TAB}s${resetcolor}|\n" "export TAIL_LOG=<integer>" "#Change the number of lines displayed from logs ('tail')" "[${DEFAULT_TAIL_LOG}]" "$(if [[ ! -z ${TAIL_LOG} ]] && [[ ${TAIL_LOG} != ${DEFAULT_TAIL_LOG} ]]; then echo "[${TAIL_LOG}]"; fi)"
-  printf "|%-${EXPORT_TAB}s---%-${COMMENT_TAB}s---%-${DEFAULT_TAB}s---%-${CURRENT_TAB}s|\n" |tr \  '-'
-  MAX_RANDOM=1
+  if [[ ! -z ${DETAILS} ]] && [[ ! -z ${HELP} ]]
+  then
+    echo -e "\nCustomizable variables before running the script (Optional):"
+    EXPORT_TAB=34
+    COMMENT_TAB=80
+    DEFAULT_TAB=10
+    CURRENT_TAB=10
+    if [[ ! -z ${OC} ]]
+    then
+      OC_LENGTH=$(echo "[${OC}]" | wc -c | awk '{print $1}')
+      if [[ ${OC_LENGTH} -gt ${CURRENT_TAB} ]]
+      then
+        CURRENT_TAB=${OC_LENGTH}
+      fi
+    fi
+    printf "|%-${EXPORT_TAB}s---%-${COMMENT_TAB}s---%-${DEFAULT_TAB}s---%-${CURRENT_TAB}s|\n" |tr \  '-'
+    printf "|%-${EXPORT_TAB}s | %-${COMMENT_TAB}s | %-${DEFAULT_TAB}s | %-${CURRENT_TAB}s|\n" "Options" "Description" "[Default]" "[Current]"
+    printf "|%-${EXPORT_TAB}s-|-%-${COMMENT_TAB}s-|-%-${DEFAULT_TAB}s-|-%-${CURRENT_TAB}s|\n" |tr \  '-'
+    printf "|${purpletext}%-${EXPORT_TAB}s${resetcolor} | %-${COMMENT_TAB}s | ${greentext}%-${DEFAULT_TAB}s${resetcolor} | ${redtext}%-${CURRENT_TAB}s${resetcolor}|\n" "export OC=[omc|omg|oc]" "#Change the must-gather tool (use 'oc' to run the script against live cluster)" "[${DEFAULT_OC}]" "$(if [[ ! -z ${OC} ]] && [[ ${OC} != ${DEFAULT_OC} ]]; then echo "[${OC}]"; fi)"
+    printf "|${purpletext}%-${EXPORT_TAB}s${resetcolor} | %-${COMMENT_TAB}s | ${greentext}%-${DEFAULT_TAB}s${resetcolor} | ${redtext}%-${CURRENT_TAB}s${resetcolor}|\n" "export ALERT_TRUNK=<interger>" "#Change the length of the Alert Descriptions" "[${DEFAULT_TRUNK}]" "$(if [[ ! -z ${ALERT_TRUNK} ]] && [[ ${ALERT_TRUNK} != ${DEFAULT_TRUNK} ]]; then echo "[${ALERT_TRUNK}]"; fi)"
+    printf "|${purpletext}%-${EXPORT_TAB}s${resetcolor} | %-${COMMENT_TAB}s | ${greentext}%-${DEFAULT_TAB}s${resetcolor} | ${redtext}%-${CURRENT_TAB}s${resetcolor}|\n" "export CONDITION_TRUNK=<interger" "#Change the length of the Operator Message in 'oc get co'" "[${DEFAULT_CONDITION_TRUNK}]" "$(if [[ ! -z ${CONDITION_TRUNK} ]] && [[ ${CONDITION_TRUNK} != ${DEFAULT_CONDITION_TRUNK} ]]; then echo "[${CONDITION_TRUNK}]"; fi)"
+    printf "|${purpletext}%-${EXPORT_TAB}s${resetcolor} | %-${COMMENT_TAB}s | ${greentext}%-${DEFAULT_TAB}s${resetcolor} | ${redtext}%-${CURRENT_TAB}s${resetcolor}|\n" "export POD_TRUNK=<interger" "#Change the length of the POD Message in 'oc get co'" "[${DEFAULT_TRUNK}]" "$(if [[ ! -z ${POD_TRUNK} ]] && [[ ${POD_TRUNK} != ${DEFAULT_TRUNK} ]]; then echo "[${POD_TRUNK}]"; fi)"
+    printf "|${purpletext}%-${EXPORT_TAB}s${resetcolor} | %-${COMMENT_TAB}s | ${greentext}%-${DEFAULT_TAB}s${resetcolor} | ${redtext}%-${CURRENT_TAB}s${resetcolor}|\n" "export MIN_RESTART=<integer>" "#Change the minimal number of restart when checking the POD restarts" "[${DEFAULT_MIN_RESTART}]" "$(if [[ ! -z ${MIN_RESTART} ]] && [[ ${MIN_RESTART} != ${DEFAULT_MIN_RESTART} ]]; then echo "[${MIN_RESTART}]"; fi)"
+    printf "|${purpletext}%-${EXPORT_TAB}s${resetcolor} | %-${COMMENT_TAB}s | ${greentext}%-${DEFAULT_TAB}s${resetcolor} | ${redtext}%-${CURRENT_TAB}s${resetcolor}|\n" "export TAIL_LOG=<integer>" "#Change the number of lines displayed from logs ('tail')" "[${DEFAULT_TAIL_LOG}]" "$(if [[ ! -z ${TAIL_LOG} ]] && [[ ${TAIL_LOG} != ${DEFAULT_TAIL_LOG} ]]; then echo "[${TAIL_LOG}]"; fi)"
+    printf "|${purpletext}%-${EXPORT_TAB}s${resetcolor} | %-${COMMENT_TAB}s | ${greentext}%-${DEFAULT_TAB}s${resetcolor} | ${redtext}%-${CURRENT_TAB}s${resetcolor}|\n" "export graytext=<color_code>" "#Replace the gray color used in the script" "[${DEFAULT_graytext}]" "$(if [[ ! -z "${graytext}" ]] && [[ "${graytext}" != "${DEFAULT_graytext}" ]]; then echo "[${graytext}]"; fi)"
+    printf "|${purpletext}%-${EXPORT_TAB}s${resetcolor} | %-${COMMENT_TAB}s | ${greentext}%-${DEFAULT_TAB}s${resetcolor} | ${redtext}%-${CURRENT_TAB}s${resetcolor}|\n" "export redtext=<color_code>" "#Replace the red color used in the script" "[${DEFAULT_redtext}]" "$(if [[ ! -z "${redtext}" ]] && [[ "${redtext}" != "${DEFAULT_redtext}" ]]; then echo "[${redtext}]"; fi)"
+    printf "|${purpletext}%-${EXPORT_TAB}s${resetcolor} | %-${COMMENT_TAB}s | ${greentext}%-${DEFAULT_TAB}s${resetcolor} | ${redtext}%-${CURRENT_TAB}s${resetcolor}|\n" "export greentext=<color_code>" "#Replace the green color used in the script" "[${DEFAULT_greentext}]" "$(if [[ ! -z "${greentext}" ]] && [[ "${greentext}" != "${DEFAULT_greentext}" ]]; then echo "[${greentext}]"; fi)"
+    printf "|${purpletext}%-${EXPORT_TAB}s${resetcolor} | %-${COMMENT_TAB}s | ${greentext}%-${DEFAULT_TAB}s${resetcolor} | ${redtext}%-${CURRENT_TAB}s${resetcolor}|\n" "export yellowtext=<color_code>" "#Replace the yellow color used in the script" "[${DEFAULT_yellowtext}]" "$(if [[ ! -z "${yellowtext}" ]] && [[ "${yellowtext}" != "${DEFAULT_yellowtext}" ]]; then echo "[${yellowtext}]"; fi)"
+    printf "|${purpletext}%-${EXPORT_TAB}s${resetcolor} | %-${COMMENT_TAB}s | ${greentext}%-${DEFAULT_TAB}s${resetcolor} | ${redtext}%-${CURRENT_TAB}s${resetcolor}|\n" "export bluetext=<color_code>" "#Replace the blue color used in the script" "[${DEFAULT_bluetext}]" "$(if [[ ! -z "${bluetext}" ]] && [[ "${bluetext}" != "${DEFAULT_bluetext}" ]]; then echo "[${bluetext}]"; fi)"
+    printf "|${purpletext}%-${EXPORT_TAB}s${resetcolor} | %-${COMMENT_TAB}s | ${greentext}%-${DEFAULT_TAB}s${resetcolor} | ${redtext}%-${CURRENT_TAB}s${resetcolor}|\n" "export purpletext=<color_code>" "#Replace the purple color used in the script" "[${DEFAULT_purpletext}]" "$(if [[ ! -z "${purpletext}" ]] && [[ "${purpletext}" != "${DEFAULT_purpletext}" ]]; then echo "[${purpletext}]"; fi)"
+    printf "|${purpletext}%-${EXPORT_TAB}s${resetcolor} | %-${COMMENT_TAB}s | ${greentext}%-${DEFAULT_TAB}s${resetcolor} | ${redtext}%-${CURRENT_TAB}s${resetcolor}|\n" "export cyantext=<color_code>" "#Replace the cyan color used in the script" "[${DEFAULT_cyantext}]" "$(if [[ ! -z "${cyantext}" ]] && [[ "${cyantext}" != "${DEFAULT_cyantext}" ]]; then echo "[${cyantext}]"; fi)"
+    printf "|${purpletext}%-${EXPORT_TAB}s${resetcolor} | %-${COMMENT_TAB}s | ${greentext}%-${DEFAULT_TAB}s${resetcolor} | ${redtext}%-${CURRENT_TAB}s${resetcolor}|\n" "export whitetext=<color_code>" "#Replace the white color used in the script" "[${DEFAULT_whitetext}]" "$(if [[ ! -z "${whitetext}" ]] && [[ "${whitetext}" != "${DEFAULT_whitetext}" ]]; then echo "[${whitetext}]"; fi)"
+    printf "|${purpletext}%-${EXPORT_TAB}s${resetcolor} | %-${COMMENT_TAB}s | ${greentext}%-${DEFAULT_TAB}s${resetcolor} | ${redtext}%-${CURRENT_TAB}s${resetcolor}|\n" "export resetcolor=<color_code>" "#Replace the color used to rest colors in the script" "[${DEFAULT_resetcolor}]" "$(if [[ ! -z "${resetcolor}" ]] && [[ "${resetcolor}" != "${DEFAULT_resetcolor}" ]]; then echo "[${resetcolor}]"; fi)"
+    printf "|%-${EXPORT_TAB}s---%-${COMMENT_TAB}s---%-${DEFAULT_TAB}s---%-${CURRENT_TAB}s|\n" |tr \  '-'
+    MAX_RANDOM=1
+  else
+    echo -e "\nYou can use the '-d' option with the '-h' to display the custommizable variables"
+  fi
   fct_version
   exit 0
 }
@@ -85,14 +100,6 @@ fct_version() {
       else
         if [[ "${NEW_VERSION}" == " N/A" ]] && [[ "${VERSION}" != " N/A" ]]
         then
-          case $(uname) in
-            "Darwin")
-              ls_option="-D +%s"
-              ;;
-            *)
-              ls_option="--time-style=+%s"
-              ;;
-          esac
           SCRIPT_mtime=$(ls -l ${ls_option} $(which $0) | awk '{print $(NF-1)}' | sed -e "s/+//")
           Current_time=$(date +%s)
           Time_Gap=$[$Current_time - $SCRIPT_mtime]
@@ -127,20 +134,20 @@ fct_title_details() {
 }
 
 fct_unsuccessful_pod_details() {
-  ALL_PODS_JSON=${ALL_PODS_JSON:-$(${OC} get pod -A -o json)}
-  Pending_PODs=$(echo "${ALL_PODS_JSON}" | jq -r ".items[] | select((.metadata.deletionTimestamp == null) and (.status.phase == \"Pending\")) | .metadata.namespace + \"/\" + .metadata.name + \"|\" + .metadata.creationTimestamp + \"|R-\" + .status.phase + \"-R|\" + (if ((.status.conditions[] | select(.type == \"PodScheduled\") | .message) != null) then (.status.conditions[] | select(.type == \"PodScheduled\") | .message[0:${POD_TRUNK}]) elif ((.status.conditions[] | select(.type == \"ContainersReady\") | .message) != null) then (.status.conditions[] | select(.type == \"ContainersReady\") | .message[0:${POD_TRUNK}]) else \"null\" end)")
+  ALL_PODS_JSON=${ALL_PODS_JSON:-$(${OC} get pod -A -o json | grep -Ev "^$|^No resources|^resource type")}
+  Pending_PODs=$(echo "${ALL_PODS_JSON}" | jq -r --arg trunk ${POD_TRUNK} '.items[] | select((.metadata.deletionTimestamp == null) and (.status.phase == "Pending")) | .metadata.namespace + "/" + .metadata.name + "|" + .metadata.creationTimestamp + "|R-" + .status.phase + "-R|" + (if ((.status.conditions[] | select(.type == "PodScheduled") | .message) != null) then (.status.conditions[] | select(.type == "PodScheduled") | (.message[0:($trunk|tonumber)])) | sub("\n";" ") elif ((.status.conditions[] | select(.type == "ContainersReady") | .message) != null) then (.status.conditions[] | select(.type == "ContainersReady") | (.message[0:($trunk|tonumber)] | sub("\n";" "))) else "null" end)')
   if [[ ! -z ${Pending_PODs} ]]
   then
     fct_title_details "Unsuccessful PODs - Pending - Details"
     echo -e "NAME|creationTimestamp|STATUS|Message\n${Pending_PODs}" | column -t -s'|' | sed -e "s/R-\([0-9a-zA-Z \.\-]*\)-R/${redtext}\1    ${resetcolor}/"
   fi
-  Terminating_PODs=$(echo "${ALL_PODS_JSON}" | jq -r ".items[] | select((.metadata.deletionTimestamp != null) and (.status.phase == \"Running\")) | .metadata.namespace + \"/\" + .metadata.name + \"|\" + .metadata.creationTimestamp + \"|\" + .metadata.deletionTimestamp + \"|(\" + (.metadata.deletionGracePeriodSeconds|tostring) + \")|Terminating|\" + (.status.conditions[] | select((.type == \"Ready\") and (.status != \"True\")) | .message[0:${POD_TRUNK}])")
+  Terminating_PODs=$(echo "${ALL_PODS_JSON}" | jq -r --arg trunk ${POD_TRUNK} '.items[] | select((.metadata.deletionTimestamp != null) and (.status.phase == "Running")) | .metadata.namespace + "/" + .metadata.name + "|" + .metadata.creationTimestamp + "|" + .metadata.deletionTimestamp + "|(" + (.metadata.deletionGracePeriodSeconds|tostring) + ")|Terminating|" + (.status.conditions[] | select((.type == "Ready") and (.status != "True")) | (.message[0:($trunk|tonumber)] | sub("\n";" ")))')
   if [[ ! -z ${Terminating_PODs} ]]
   then
     fct_title_details "Unsuccessful PODs - Terminating - Details"
     echo -e "NAME|creationTimestamp|deletionTimestamp|(GracePeriodSeconds)|STATUS|Message\n${Terminating_PODs}" | column -t -s'|' | sed -e "s/Terminating/${yellowtext}&${resetcolor}/"
   fi
-  Failed_PODs=$(echo "${ALL_PODS_JSON}"| jq -r ".items[] | select((.metadata.deletionTimestamp == null) and (.status.phase == \"Running\") and (.status | (.containerStatuses != null) and (.containerStatuses[].state | to_entries[] | .key == \"waiting\"))) | .metadata.namespace + \"/\" + .metadata.name + \"|\" + .metadata.creationTimestamp + \"|\" + (.status.conditions[] | select(.type == \"Ready\") | .lastTransitionTime) + \"|R-\" + (.status.containerStatuses[] | select(.state.waiting.reason != null) | .state.waiting.reason) + \"-R|\" + (.status.conditions[] | select(.type == \"Ready\") | .message[0:${POD_TRUNK}])")
+  Failed_PODs=$(echo "${ALL_PODS_JSON}"| jq -r --arg trunk ${POD_TRUNK} '.items[] | select((.metadata.deletionTimestamp == null) and (.status.phase == "Running") and (.status | (.containerStatuses != null) and (.containerStatuses[].state | to_entries[] | .key == "waiting"))) | .metadata.namespace + "/" + .metadata.name + "|" + .metadata.creationTimestamp + "|" + (.status.conditions[] | select(.type == "Ready") | .lastTransitionTime) + "|R-" + (.status.containerStatuses[] | select(.state.waiting.reason != null) | .state.waiting.reason) + "-R|" + (.status.conditions[] | select(.type == "Ready") | (.message[0:($trunk|tonumber)] | sub("\n";" ")))')
   if [[ ! -z ${Failed_PODs} ]]
   then
     fct_title_details "Unsuccessful PODs - Failed - Details"
@@ -149,7 +156,8 @@ fct_unsuccessful_pod_details() {
 }
 
 fct_unsuccessful_container_details() {
-  ALL_PODS=${ALL_PODS:-$(${OC} get pod -A)}
+  ALL_PODS=${ALL_PODS:-$(${OC} get pod -A | grep -Ev "^$|^No resources|^resource type")}
+  ALL_PODS_JSON=${ALL_PODS_JSON:-$(${OC} get pod -A -o json | grep -Ev "^$|^No resources|^resource type")}
   UNCOMPLETE_POD_LIST=$(echo "${ALL_PODS}" | grep -Ev "^NAME|Completed|Succeeded|1/1|2/2|3/3|4/4|5/5|6/6|7/7|8/8|9/9|10/10|11/11|12/12|13/13|14/14|15/15" | awk '{print $1"/"$2}')
   echo "${ALL_PODS}" | grep -E "^NAME"
   for POD_details in ${UNCOMPLETE_POD_LIST}
@@ -158,10 +166,10 @@ fct_unsuccessful_container_details() {
     pod_name=$(echo ${POD_details} | cut -d'/' -f2)
     echo "${ALL_PODS}" | grep -E "^${namespace} *${pod_name}" | sed -e "s/ [0-9]*\/[0-9]* /${yellowtext}&${resetcolor}/"
     CONTAINER_DETAILS=""
-    EXTRACT_CONTAINER_DETAILS=$(${OC} get pod -n ${namespace} ${pod_name} -o json | jq -r ".status | if (.containerStatuses != null) then (.containerStatuses[] | select(.ready != true) | { \"name\": .name, \"state\": .state | to_entries[] | .key, \"restartCount\": .restartCount, \"startedAt\": (if (.lastState != {}) then (.lastState | to_entries[] | .value.startedAt) else (.state | to_entries[] | .value.startedAt) end), \"exitCode\": (if (.lastState != {}) then (.lastState | to_entries[] | .value.exitCode) else (.state | to_entries[] | .value.exitCode) end), \"reason\": (if (.state | to_entries[] | .value.reason == \"CrashLoopBackOff\" ) then (.state | to_entries[] | .value.reason) elif (.lastState != {}) then (.lastState | to_entries[] | .value.reason) else (.state | to_entries[] | .value.reason) end), \"message\": .state | to_entries[] | .value.message[0:${POD_TRUNK}] } ) else \"\" end")
+    EXTRACT_CONTAINER_DETAILS=$(echo "${ALL_PODS_JSON}" | jq -r --arg namespace ${namespace} --arg podname ${pod_name} --arg trunk ${POD_TRUNK} '.items[] | select((.metadata.namespace == $namespace) and (.metadata.name == $podname)) | .status | if (.containerStatuses != null) then (.containerStatuses[] | select(.ready != true) | { "name": .name, "state": .state | to_entries[] | .key, "restartCount": .restartCount, "startedAt": (if (.lastState != {}) then (.lastState | to_entries[] | .value.startedAt) else (.state | to_entries[] | .value.startedAt) end), "exitCode": (if (.lastState != {}) then (.lastState | to_entries[] | .value.exitCode) else (.state | to_entries[] | .value.exitCode) end), "reason": (if (.state | to_entries[] | .value.reason == "CrashLoopBackOff" ) then (.state | to_entries[] | .value.reason) elif (.lastState != {}) then (.lastState | to_entries[] | .value.reason) else (.state | to_entries[] | .value.reason) end), "message": .state | to_entries[] | .value.message[0:($trunk|tonumber)] | sub("\n";" ") } ) else "" end')
     if [[ ! -z ${EXTRACT_CONTAINER_DETAILS} ]]
     then
-      CONTAINER_DETAILS=$(echo "${EXTRACT_CONTAINER_DETAILS}" | sed -e "s/\\\n/_/g" | jq -r '"\(.name)+\(.state)+\(.restartCount)+\(.startedAt)+\(.exitCode)+\(.reason)+\(.message)"' | sed -e "s/ /_/g")
+      CONTAINER_DETAILS=$(echo "${EXTRACT_CONTAINER_DETAILS}" | sed -e "s/\\\n/_/g" | jq -r '"\(.name)+\(.state)+\(.restartCount)+\(.startedAt)+\(.exitCode)+\(.reason)+\(.message | sub("\n";" "))"' | sed -e "s/ /_/g")
     fi
     for line in "Container Name+state+restartCount+startedAt+exitCode+reason+message" "--------------+-----+------------+---------+--------+--------+---------" ${CONTAINER_DETAILS}
     do
@@ -172,7 +180,8 @@ fct_unsuccessful_container_details() {
 }
 
 fct_restart_container_details() {
-  ALL_PODS=${ALL_PODS:-$(${OC} get pod -A)}
+  ALL_PODS=${ALL_PODS:-$(${OC} get pod -A | grep -Ev "^$|^No resources|^resource type")}
+  ALL_PODS_JSON=${ALL_PODS_JSON:-$(${OC} get pod -A -o json | grep -Ev "^$|^No resources|^resource type")}
   RESTART_POD_LIST=$(echo "${ALL_PODS}" | awk -v min_restart=${MIN_RESTART} '($5 > min_restart){print $1"/"$2}' | grep -Ev "^NAME")
   echo "${ALL_PODS}" | grep -E "^NAME"
   for POD_details in ${RESTART_POD_LIST}
@@ -182,7 +191,7 @@ fct_restart_container_details() {
     pod_name=$(echo ${POD_details} | cut -d'/' -f2)
     echo "${ALL_PODS}" | grep -E "^${namespace} *${pod_name}" | sed -e "s/ [0-9]\{1,2\} /${yellowtext}&${resetcolor}/" -e "s/ [0-9]\{3,5\} /${redtext}&${resetcolor}/"
     ### The POD restartCount is now a Total of all containers restartCount, updating the query to display all containers with "restartCount > 0" sorted by highest numbers
-    CONTAINER_DETAILS=$(${OC} get pod -n ${namespace} ${pod_name} -o json | jq -r ".status.containerStatuses | sort_by(-.restartCount,.name) | .[] | select(.restartCount >  0) | \"\(.name)+\(.state | to_entries[] | .key)+\(.restartCount)+\(if (.lastState != {}) then (.lastState | to_entries[] | .value.startedAt) else (.state | to_entries[] | .value.startedAt) end)+\(if (.lastState != {}) then (.lastState | to_entries[] | .value.finishedAt) else null end)+\(if (.lastState != {}) then (.lastState | to_entries[] | .value.exitCode) else (.state | to_entries[] | .value.exitCode) end)+\(if (.state | to_entries[] | .value.reason == \"CrashLoopBackOff\" ) then (.state | to_entries[] | .value.reason) elif (.lastState != {}) then (.lastState | to_entries[] | .value.reason) else (.state | to_entries[] | .value.reason) end)\"")
+    CONTAINER_DETAILS=$(echo "${ALL_PODS_JSON}" | jq -r --arg namespace ${namespace} --arg podname ${pod_name} '.items[] | select((.metadata.namespace == $namespace) and (.metadata.name == $podname)) | .status.containerStatuses | sort_by(-.restartCount,.name) | .[] | select(.restartCount >  0) | "\(.name)+\(.state | to_entries[] | .key)+\(.restartCount)+\(if (.lastState != {}) then (.lastState | to_entries[] | .value.startedAt) else (.state | to_entries[] | .value.startedAt) end)+\(if (.lastState != {}) then (.lastState | to_entries[] | .value.finishedAt) else null end)+\(if (.lastState != {}) then (.lastState | to_entries[] | .value.exitCode) else (.state | to_entries[] | .value.exitCode) end)+\(if (.state | to_entries[] | .value.reason == "CrashLoopBackOff" ) then (.state | to_entries[] | .value.reason) elif (.lastState != {}) then (.lastState | to_entries[] | .value.reason) else (.state | to_entries[] | .value.reason) end)"')
     LONGEST_NAME=$(echo "${CONTAINER_DETAILS}" | awk -F'+' 'BEGIN{longest=0}{if(length($1) > longest){longest=length($1)}}END{print longest}')
     LONGEST_NAME=${LONGEST_NAME:-0}
     if [[ ${LONGEST_NAME} -gt 32 ]]
@@ -205,24 +214,48 @@ DEFAULT_TRUNK="100"
 DEFAULT_CONDITION_TRUNK="220"
 DEFAULT_MIN_RESTART="10"
 DEFAULT_TAIL_LOG="15"
+DEFAULT_graytext="\x1B[30m"
+DEFAULT_redtext="\x1B[31m"
+DEFAULT_greentext="\x1B[32m"
+DEFAULT_yellowtext="\x1B[33m"
+DEFAULT_bluetext="\x1B[34m"
+DEFAULT_purpletext="\x1B[35m"
+DEFAULT_cyantext="\x1B[36m"
+DEFAULT_whitetext="\x1B[37m"
+DEFAULT_resetcolor="\x1B[0m"
 # Source URLs & version time_gap
 SOURCE_RAW_URL="https://raw.githubusercontent.com/vlours/mg_cluster_status/main/mg_cluster_status.sh"
 SOURCE_URL="https://github.com/vlours/mg_cluster_status/"
 Time_Gap_Alert=${Time_Gap_Alert:-7776000}         # => 90 days gap
 # Color list
-graytext="\x1B[30m"
-redtext="\x1B[31m"
-greentext="\x1B[32m"
-yellowtext="\x1B[33m"
-bluetext="\x1B[34m"
-purpletext="\x1B[35m"
-cyantext="\x1B[36m"
-whitetext="\x1B[37m"
-resetcolor="\x1B[0m"
+graytext=${graytext:-${DEFAULT_graytext}}
+redtext=${redtext:-${DEFAULT_redtext}}
+greentext=${greentext:-${DEFAULT_greentext}}
+yellowtext=${yellowtext:-${DEFAULT_yellowtext}}
+bluetext=${bluetext:-${DEFAULT_bluetext}}
+purpletext=${purpletext:-${DEFAULT_purpletext}}
+cyantext=${cyantext:-${DEFAULT_cyantext}}
+whitetext=${whitetext:-${DEFAULT_whitetext}}
+resetcolor=${resetcolor:-${DEFAULT_resetcolor}}
 # Max random number to check for update
 MAX_RANDOM=10
 # Set a default STD_ERR, which can be replaced for debugging to "/dev/stderr"
 STD_ERR="${STD_ERR:-/dev/null}"
+# Content variables not allowing exported content
+unset NODE_JSON NOT_READY KUBELETCONFIG AVAILABLE_MACHINES CLUSTERAUTOSCALER NODE_JSON MACHINESETS_JSON MACHINES_JSON CLUSTER_VERSION CO_MISS_VERSION_OUTPUT UNHEALTHY_OPERATORS MCP_NODE_DEGRADED PROCESSING_MCP DEGRADED_NODES MCO_PODS ALL_SCC_JSON ALL_PODS ALL_PODS_WIDE ALL_PODS_JSON
+# Plateform variables
+case $(uname) in
+  "Darwin")
+    LAST_28days=$(date -r $[$(date +%s) - 2419200] +%Y-%m)
+    THIS_month=$(date -r $(date +%s) +%Y-%m)
+    ls_option="-D +%s"
+    ;;
+  *)
+    LAST_28days=$(date -d @$[$(date +%s) - 2419200] +%Y-%m)
+    THIS_month=$(date -d @$(date +%s) +%Y-%m)
+    ls_option="--time-style=+%s"
+    ;;
+esac
 
 ##### Main
 if [[ $# != 0 ]]
@@ -232,7 +265,7 @@ then
     echo -e "Invalid option: ${1}\n"
     fct_help && exit 1
   fi
-  while getopts :acevMmnopsdh arg; do
+  while getopts :acevMmnopsSdh arg; do
   case $arg in
       a)
         ALERTS=true
@@ -270,11 +303,15 @@ then
         STATICPOD=true
         HAS_DETAILS=true
         ;;
+      S)
+        SCC=true
+        HAS_DETAILS=true
+        ;;
       d)
         DETAILS=true
         ;;
       h)
-        fct_help
+        HELP=true
         ;;
       ?)
         echo -e "Invalid option: ${1}\n"
@@ -286,6 +323,10 @@ else
   ALL=true
 fi
 
+if [[ ! -z ${HELP} ]]
+then
+  fct_help
+fi
 if [[ $* == "-d" ]]
 then
   echo "The '-d' option should only be use with one or multiple filters"
@@ -336,8 +377,8 @@ then
   fct_header "NODE STATUS"
   fct_title "Nodes"
   ${OC} get nodes -o wide | grep -Ev "^$|^No resources|^resource type" | sed -e "s/SchedulingDisabled/${yellowtext}&${resetcolor}/" -e "s/NotReady/${redtext}&${resetcolor}/" -e "s/master/${cyantext}&${resetcolor}/g" -e "s/worker/${purpletext}&${resetcolor}/g" -e "s/infra/${yellowtext}&${resetcolor}/g"
-  NODE_JSON=$(${OC} get nodes -o json | grep -Ev "^$|^No resources|^resource type")
-  NOT_READY=$(echo "${NODE_JSON}" | grep -Ev "^$|^No resources|^resource type" | jq -r '.items[] | select(.status.conditions[] | select((.type == "Ready") and (.status != "True"))) | "\(.metadata.name)|NotReady|\(.status.conditions[] | select(.type == "Ready") | .lastTransitionTime)"')
+  NODE_JSON=${NODE_JSON:-$(${OC} get nodes -o json | grep -Ev "^$|^No resources|^resource type")}
+  NOT_READY=${NOT_READY:-$(echo "${NODE_JSON}" | grep -Ev "^$|^No resources|^resource type" | jq -r '.items[] | select(.status.conditions[] | select((.type == "Ready") and (.status != "True"))) | "\(.metadata.name)|NotReady|\(.status.conditions[] | select(.type == "Ready") | .lastTransitionTime)"')}
   if [[ ! -z ${NOT_READY} ]]
   then
     fct_title "NotReady Nodes"
@@ -345,21 +386,11 @@ then
   fi
   if [[ ! -z ${DETAILS} ]]
   then
-    case $(uname) in
-      "Darwin")
-        LAST_28days=$(date -r $[$(date +%s) - 2419200] +%Y-%m)
-        THIS_month=$(date -r $(date +%s) +%Y-%m)
-        ;;
-      *)
-        LAST_28days=$(date -d @$[$(date +%s) - 2419200] +%Y-%m)
-        THIS_month=$(date -d @$(date +%s) +%Y-%m)
-        ;;
-    esac
     fct_title_details "Node details"
     echo "${NODE_JSON}" | jq -r '"|CPU||Memory||ephemeral-storage|||||\nNodename|Capacity|Allocatable|Capacity|Allocatable|Capacity|Allocatable|pods|hugepages-1Gi|hugepages-2Mi|Taints",(.items | sort_by(.metadata.name)|.[]|"\(.metadata.name)|\(.status.capacity.cpu)|\(.status.allocatable.cpu)|\(.status.capacity.memory)|\(.status.allocatable.memory)|\(.status.capacity."ephemeral-storage")|\((.status.allocatable."ephemeral-storage"|tonumber)/1024|round)Ki|\(.status.capacity.pods)|\(.status.capacity."hugepages-1Gi")|\(.status.capacity."hugepages-2Mi")|\(if(.spec.taints != null) then [.spec.taints[]] else "null" end)")'| column -s'|' -t | sed  -e "s/master/${cyantext}&${resetcolor}/g" -e "s/worker/${purpletext}&${resetcolor}/g" -e "s/infra/${yellowtext}&${resetcolor}/g" -e "s/node.kubernetes.io\/[a-z\-]*/${redtext}&${resetcolor}/g"
     fct_title_details "Node Conditions (yellow = NotReady transition within last 28-59 days)"
     echo "${NODE_JSON}" | jq -r '"|Ready|||MemoryPressure|||DiskPressure|||PIDPressure|||\nNodename|Status|lastTransitionTime|lastHeartbeatTime|Status|lastTransitionTime|lastHeartbeatTime|Status|lastTransitionTime|lastHeartbeatTime|Status|lastTransitionTime|lastHeartbeatTime|",(.items | sort_by(.metadata.name)|.[]|"\(.metadata.name)|\(.status.conditions[]|select(.type == "Ready")|"\(.status)|\(.lastTransitionTime)|\(.lastHeartbeatTime)")|\(.status.conditions[]|select(.type == "MemoryPressure")|"\(.status)|\(.lastTransitionTime)|\(.lastHeartbeatTime)")|\(.status.conditions[]|select(.type == "DiskPressure")|"\(.status)|\(.lastTransitionTime)|\(.lastHeartbeatTime)")|\(.status.conditions[]|select(.type == "PIDPressure")|"\(.status)|\(.lastTransitionTime)|\(.lastHeartbeatTime)")")' | column -t -s'|' | sed -e "s/\(^[- .a-zA-Z0-9]* *\)\([TF][a-z]* *\)\(${THIS_month}[-:T0-9]*Z\)/\1\2${yellowtext}\3${resetcolor}/" -e "s/\(^[- .a-zA-Z0-9]* *\)\([TF][a-z]* *\)\(${LAST_28days}[-:T0-9]*Z\)/\1\2${yellowtext}\3${resetcolor}/" -e "s/\(^[- .a-zA-Z0-9]* *\)True/\1${greentext}True${resetcolor}/" -e "s/\(^[- .a-zA-Z0-9]* *\)False/\1${redtext}False${resetcolor}/" -e "s/\([-:TZ0-9]*Z *\)True/\1${redtext}True${resetcolor}/g" -e "s/\([-:T0-9]*Z *\)False/\1${greentext}False${resetcolor}/g"
-    KUBELETCONFIG=$(${OC} get kubeletconfig.machineconfiguration.openshift.io -o json | grep -Ev "^$|^No resources|^resource type" | jq -r 'if(.items != null) then . else null end')
+    KUBELETCONFIG=${KUBELETCONFIG:-$(${OC} get kubeletconfig.machineconfiguration.openshift.io -o json | grep -Ev "^$|^No resources|^resource type" | jq -r 'if(.items != null) then . else null end')}
     if [[ "${KUBELETCONFIG}" != "null" ]] && [[ "${KUBELETCONFIG}" != "" ]]
     then
       fct_title_details "System Reserved"
@@ -374,14 +405,14 @@ fi
 if [[ ! -z ${MACHINES} ]] || [[ ! -z ${ALL} ]]
 then
   fct_header "MACHINE STATUS"
-  AVAILABLE_MACHINES=$(${OC} get machine.machine.openshift.io -n openshift-machine-api -o wide 2>/dev/null | grep -Ev "^$|^No resources|^resource type")
+  AVAILABLE_MACHINES=${AVAILABLE_MACHINES:-$(${OC} get machine.machine.openshift.io -n openshift-machine-api -o wide 2>/dev/null | grep -Ev "^$|^No resources|^resource type")}
   if [[ ! -z ${AVAILABLE_MACHINES} ]]
   then
-    CLUSTERAUTOSCALER=$(${OC} get clusterautoscaler.autoscaling.openshift.io default -o json 2>&1 | grep -Ev "^$|^No resources|^resource type" | jq -r 'if(.kind != null) then . | del(.metadata.annotations) else null end')
+    CLUSTERAUTOSCALER=${CLUSTERAUTOSCALER:-$(${OC} get clusterautoscaler.autoscaling.openshift.io default -o json 2>&1 | grep -Ev "^$|^No resources|^resource type" | jq -r 'if(.kind != null) then . | del(.metadata.annotations) else null end')}
     if [[ "${CLUSTERAUTOSCALER}" != "null" ]] && [[ "${CLUSTERAUTOSCALER}" != "" ]]
     then
       fct_title "ClusterAutoscaller"
-      NODE_JSON=$(${OC} get nodes -o json | grep -Ev "^$|^No resources|^resource type")
+      NODE_JSON=${NODE_JSON:-$(${OC} get nodes -o json | grep -Ev "^$|^No resources|^resource type")}
       currentNodesTotal=$(echo "${NODE_JSON}" | jq -r '.items | length')
       currentCoreTotal=$(echo "${NODE_JSON}" | jq -r '.items[] | .status.capacity.cpu' | awk 'BEFORE{i=0}{i=i+$1}END{print i}')
       currentAmdgpuTotal=$(echo "${NODE_JSON}" | jq -r '.items[] | if .status.capacity."amd.com/gpu" == null then "0" else .status.capacity."amd.com/gpu" end' | awk 'BEFORE{i=0}{i=i+$1}END{print i}')
@@ -397,18 +428,18 @@ then
       ${OC} get MachineAutoscaler.autoscaling.openshift.io -n openshift-machine-api 2>&1 | sed -e "s/No resource[- a-zA-Z0-9]*\./${yellowtext}&${resetcolor}/"
     fi
     fct_title "MachineSets"
-    MACHINESETS_JSON=$(${OC} get machineset.machine.openshift.io -n openshift-machine-api -o json)
+    MACHINESETS_JSON=${MACHINESETS_JSON:-$(${OC} get machineset.machine.openshift.io -n openshift-machine-api -o json)}
     if [[ -z ${DETAILS} ]]
     then
       ${OC} get machineset.machine.openshift.io -n openshift-machine-api -o json | grep -Ev "^$|^No resources|^resource type" | jq -r '"NAME|DESIRED|CURRENT|READY|AVAILABLE|creationTimestamp",(.items[] | "\(.metadata.name)|\(.spec.replicas)|\(if .spec.replicas != .status.replicas then "Y\(.status.replicas)" else "G\(.status.replicas)" end)|\(if .status.readyReplicas != null then (if .spec.replicas != .status.readyReplicas then "Y\(.status.readyReplicas)" else "G\(.status.readyReplicas)" end) else (if .spec.replicas == 0 then "0" else "R0" end) end)|\(if .status.availableReplicas != null then (if .spec.replicas != .status.availableReplicas then "Y\(.status.availableReplicas)" else "G\(.status.availableReplicas)" end) else (if .spec.replicas == 0 then "0" else "Y0" end) end)|\(.metadata.creationTimestamp)")' | column -t -s'|' | sed -e "s/G\([0-9]\{1,5\}\\)/${greentext}\1 ${resetcolor}/g" -e "s/R\([0-9]\{1,5\}\\)/${redtext}\1 ${resetcolor}/g" -e "s/Y\([0-9]\{1,5\}\\)/${yellowtext}\1 ${resetcolor}/g" -e "s/^[-a-zAZ0-9]*master[-a-zAZ0-9]*/${cyantext}&${resetcolor}/" -e "s/^[-a-zAZ0-9]*worker[-a-zAZ0-9]*/${purpletext}&${resetcolor}/" -e "s/^[-a-zAZ0-9]*infra[-a-zAZ0-9]*/${yellowtext}&${resetcolor}/"
     else
-      ${OC} get machineset.machine.openshift.io -n openshift-machine-api -o json | grep -Ev "^$|^No resources|^resource type" | jq -r --arg trunk ${CONDITION_TRUNK} '"NAME|DESIRED|CURRENT|READY|AVAILABLE|creationTimestamp|errorReason|errorMessage",(.items[] | "\(.metadata.name)|\(.spec.replicas)|\(if .spec.replicas != .status.replicas then "Y\(.status.replicas)" else "G\(.status.replicas)" end)|\(if .status.readyReplicas != null then (if .spec.replicas != .status.readyReplicas then "Y\(.status.readyReplicas)" else "G\(.status.readyReplicas)" end) else (if .spec.replicas == 0 then "0" else "R0" end) end)|\(if .status.availableReplicas != null then (if .spec.replicas != .status.availableReplicas then "Y\(.status.availableReplicas)" else "G\(.status.availableReplicas)" end) else (if .spec.replicas == 0 then "0" else "Y0" end) end)|\(.metadata.creationTimestamp)|\(if .status.errorReason != null then .status.errorReason[0:$trunk] else "" end)|\(if .status.errorMessage != null then .status.errorMessage[0:$trunk] else "" end)")' | column -t -s'|' | sed -e "s/G\([0-9]\{1,5\}\\)/${greentext}\1 ${resetcolor}/g" -e "s/R\([0-9]\{1,5\}\\)/${redtext}\1 ${resetcolor}/g" -e "s/Y\([0-9]\{1,5\}\\)/${yellowtext}\1 ${resetcolor}/g" -e "s/^[-a-zAZ0-9]*master[-a-zAZ0-9]*/${cyantext}&${resetcolor}/" -e "s/^[-a-zAZ0-9]*worker[-a-zAZ0-9]*/${purpletext}&${resetcolor}/" -e "s/^[-a-zAZ0-9]*infra[-a-zAZ0-9]*/${yellowtext}&${resetcolor}/"
+      ${OC} get machineset.machine.openshift.io -n openshift-machine-api -o json | grep -Ev "^$|^No resources|^resource type" | jq -r --arg trunk ${CONDITION_TRUNK} '"NAME|DESIRED|CURRENT|READY|AVAILABLE|creationTimestamp|errorReason|errorMessage",(.items[] | "\(.metadata.name)|\(.spec.replicas)|\(if .spec.replicas != .status.replicas then "Y\(.status.replicas)" else "G\(.status.replicas)" end)|\(if .status.readyReplicas != null then (if .spec.replicas != .status.readyReplicas then "Y\(.status.readyReplicas)" else "G\(.status.readyReplicas)" end) else (if .spec.replicas == 0 then "0" else "R0" end) end)|\(if .status.availableReplicas != null then (if .spec.replicas != .status.availableReplicas then "Y\(.status.availableReplicas)" else "G\(.status.availableReplicas)" end) else (if .spec.replicas == 0 then "0" else "Y0" end) end)|\(.metadata.creationTimestamp)|\(if .status.errorReason != null then .status.errorReason[0:($trunk|tonumber)] else "" end)|\(if .status.errorMessage != null then (.status.errorMessage[0:($trunk|tonumber)] | sub("\n";" ")) else "" end)")' | column -t -s'|' | sed -e "s/G\([0-9]\{1,5\}\\)/${greentext}\1 ${resetcolor}/g" -e "s/R\([0-9]\{1,5\}\\)/${redtext}\1 ${resetcolor}/g" -e "s/Y\([0-9]\{1,5\}\\)/${yellowtext}\1 ${resetcolor}/g" -e "s/^[-a-zAZ0-9]*master[-a-zAZ0-9]*/${cyantext}&${resetcolor}/" -e "s/^[-a-zAZ0-9]*worker[-a-zAZ0-9]*/${purpletext}&${resetcolor}/" -e "s/^[-a-zAZ0-9]*infra[-a-zAZ0-9]*/${yellowtext}&${resetcolor}/"
     fi
     fct_title "Machines"
     echo "${AVAILABLE_MACHINES}" | grep -Ev "^$|^No resources|^resource type" | sed -e "s/[Rr]unning/${greentext}&${resetcolor}/g" -e "s/Deleting/${redtext}&${resetcolor}/g" -e "s/shutting-down/${redtext}&${resetcolor}/g" -e "s/pending/${redtext}&${resetcolor}/g" -e "s/Provision[a-z]\{1,5\}/${yellowtext}&${resetcolor}/g"  -e "s/^[-a-zAZ0-9]*master[-a-zAZ0-9]*/${cyantext}&${resetcolor}/" -e "s/^[-a-zAZ0-9]*worker[-a-zAZ0-9]*/${purpletext}&${resetcolor}/" -e "s/^[-a-zAZ0-9]*infra[-a-zAZ0-9]*/${yellowtext}&${resetcolor}/"
     if [[ ! -z ${DETAILS} ]]
     then
-      MACHINESETS_JSON=$(${OC} get machine.machine.openshift.io -n openshift-machine-api -o json | grep -Ev "^$|^No resources|^resource type")
+      MACHINES_JSON=${MACHINES_JSON:-$(${OC} get machine.machine.openshift.io -n openshift-machine-api -o json | grep -Ev "^$|^No resources|^resource type")}
     fi
   else
     echo -e "No resources found in openshift-machine-api namespace."
@@ -420,15 +451,15 @@ if [[ ! -z ${OPERATORS} ]] || [[ ! -z ${ALL} ]]
 then
   fct_header "OPERATOR STATUS"
   fct_title "Unhealthy Cluster Operators"
-  ${OC} get clusteroperator.config.openshift.io -o json 2>${STD_ERR} | grep -Ev "^$|^No resources|^resource type" | jq -r '"|NAME|VERSION|AVAILABLE|PROGRESSING|DEGRADED|LASTTRANSTION|MESSAGE",(.items[] | "|\(.metadata.name)|\(.status.versions[] | select(.name == "operator") | .version)|\(.status.conditions[] |select(.type == "Available") | .status)|\(.status.conditions[] |select(.type == "Progressing") | .status)|\(.status.conditions[] |select(.type == "Degraded") | .status)|\(if ((.status.conditions[] | select(.type == "Degraded") | .message) != null and (.status.conditions[] |select(.type == "Degraded") | .status) == "True") then "\(.status.conditions[] | select(.type == "Degraded") | .lastTransitionTime + "|" + .message)"  elif ((.status.conditions[] |select(.type == "Progressing") | .message) != null and (.status.conditions[] |select(.type == "Progressing") | .status) == "True") then "\(.status.conditions[] |select(.type == "Progressing") | .lastTransitionTime + "|" + .message)" elif ((.status.conditions[] |select(.type == "Available") | .message) != null and (.status.conditions[] |select(.type == "Available") | .status) == "True") then "\(.status.conditions[] |select(.type == "Available") | .lastTransitionTime + "|" + .message)" else "" end)")' 2>${STD_ERR} | grep -v "True|False|False" | grep "^|" | awk -F'|' -v trunk=${CONDITION_TRUNK} '{printf "%s|%s|",$2,$3; if($4 == "AVAILABLE"){printf "%s|",$4} else if($4 == "True"){printf "G%s|",$4}else{printf "R%s|",$4}; if($5 == "PROGRESSING"){printf "%s|",$5} else if($5 == "True"){printf "Y%s|",$5}else{printf "G%s|",$5}; if($6 == "DEGRADED"){printf "%s|",$6} else if($6 == "True"){printf "R%s|",$6}else{printf "G%s|",$6}; desc=substr($8,1,trunk); printf "%s|%s|\n",$7,desc}' | column -t -s '|' | sed -e "s/G\([FT][a-z]*\)/${greentext}\1 ${resetcolor}/g" -e "s/Y\([FT][a-z]*\)/${yellowtext}\1 ${resetcolor}/g" -e "s/R\([FT][a-z]*\)/${redtext}\1 ${resetcolor}/g"
-  CLUSTER_VERSION=$(${OC} get clusterversion.config.openshift.io version -o json | grep -Ev "^$|^No resources|^resource type" | jq -r .status.desired.version 2>${STD_ERR})
-  CO_MISS_VERSION_OUTPUT=$(${OC} get clusteroperator.config.openshift.io -o json | grep -Ev "^$|^No resources|^resource type" | jq -r --arg ClusterVersion "${CLUSTER_VERSION:-"null"}" '.items[] | select((.metadata.ownerReferences != null) and (.metadata.ownerReferences[].kind == "ClusterVersion") and (.status.versions[] | select((.name == "operator") and (.version != $ClusterVersion)))) | "\(.metadata.name)|\(.status.versions[] | select(.name == "operator") | .version)"')
+  ${OC} get clusteroperator.config.openshift.io -o json 2>${STD_ERR} | grep -Ev "^$|^No resources|^resource type" | jq -r '"|NAME|VERSION|AVAILABLE|PROGRESSING|DEGRADED|LASTTRANSTION|MESSAGE",(.items[] | "|\(.metadata.name)|\(.status.versions[] | select(.name == "operator") | .version)|\(.status.conditions[] |select(.type == "Available") | .status)|\(.status.conditions[] |select(.type == "Progressing") | .status)|\(.status.conditions[] |select(.type == "Degraded") | .status)|\(if ((.status.conditions[] | select(.type == "Degraded") | .message) != null and (.status.conditions[] |select(.type == "Degraded") | .status) == "True") then "\(.status.conditions[] | select(.type == "Degraded") | .lastTransitionTime + "|" + .message | sub("\n";" "))"  elif ((.status.conditions[] |select(.type == "Progressing") | .message) != null and (.status.conditions[] |select(.type == "Progressing") | .status) == "True") then "\(.status.conditions[] |select(.type == "Progressing") | .lastTransitionTime + "|" + (.message | sub("\n";" ")))" elif ((.status.conditions[] |select(.type == "Available") | .message) != null and (.status.conditions[] |select(.type == "Available") | .status) == "True") then "\(.status.conditions[] |select(.type == "Available") | .lastTransitionTime + "|" + (.message | sub("\n";" ")))" else "" end)")' 2>${STD_ERR} | grep -v "True|False|False" | grep "^|" | awk -F'|' -v trunk=${CONDITION_TRUNK} '{printf "%s|%s|",$2,$3; if($4 == "AVAILABLE"){printf "%s|",$4} else if($4 == "True"){printf "G%s|",$4}else{printf "R%s|",$4}; if($5 == "PROGRESSING"){printf "%s|",$5} else if($5 == "True"){printf "Y%s|",$5}else{printf "G%s|",$5}; if($6 == "DEGRADED"){printf "%s|",$6} else if($6 == "True"){printf "R%s|",$6}else{printf "G%s|",$6}; desc=substr($8,1,trunk); printf "%s|%s|\n",$7,desc}' | column -t -s '|' | sed -e "s/G\([FT][a-z]*\)/${greentext}\1 ${resetcolor}/g" -e "s/Y\([FT][a-z]*\)/${yellowtext}\1 ${resetcolor}/g" -e "s/R\([FT][a-z]*\)/${redtext}\1 ${resetcolor}/g"
+  CLUSTER_VERSION=${CLUSTER_VERSION:-$(${OC} get clusterversion.config.openshift.io version -o json | grep -Ev "^$|^No resources|^resource type" | jq -r .status.desired.version 2>${STD_ERR})}
+  CO_MISS_VERSION_OUTPUT=${CO_MISS_VERSION_OUTPUT:-$(${OC} get clusteroperator.config.openshift.io -o json | grep -Ev "^$|^No resources|^resource type" | jq -r --arg ClusterVersion "${CLUSTER_VERSION:-"null"}" '.items[] | select((.metadata.ownerReferences != null) and (.metadata.ownerReferences[].kind == "ClusterVersion") and (.status.versions[] | select((.name == "operator") and (.version != $ClusterVersion)))) | "\(.metadata.name)|\(.status.versions[] | select(.name == "operator") | .version)"')}
   if [[ ! -z "${CO_MISS_VERSION_OUTPUT}" ]]
   then
     fct_title "Not Updated Cluster Operators"
     echo -e "NAME|VERSION\n${CO_MISS_VERSION_OUTPUT}" | column -t -s'|' | sed -e "s/[0-9].[0-9]\{1,2\}.[0-9]\{1,2\}/${redtext}&${resetcolor}/" -e "s/^[a-z\-]*/${purpletext}&${resetcolor}/"
   fi
-  UNHEALTHY_OPERATORS=$(${OC} get clusteroperator.config.openshift.io -o json | grep -Ev "^$|^No resources|^resource type" | jq -r '.items[] | select(.status.conditions[] | ((.type == "Available") and (.status == "False")) or ((.type == "Progressing") and (.status == "True")) or ((.type == "Degraded") and (.status == "True"))) | .metadata.name' 2>${STD_ERR} | sort -u)
+  UNHEALTHY_OPERATORS=${UNHEALTHY_OPERATORS:-$(${OC} get clusteroperator.config.openshift.io -o json | grep -Ev "^$|^No resources|^resource type" | jq -r '.items[] | select(.status.conditions[] | ((.type == "Available") and (.status == "False")) or ((.type == "Progressing") and (.status == "True")) or ((.type == "Degraded") and (.status == "True"))) | .metadata.name' 2>${STD_ERR} | sort -u)}
   if [[ ! -z ${DETAILS} ]] && [[ ! -z ${UNHEALTHY_OPERATORS} ]]
   then
     fct_title_details "Unhealthy Cluster Operators - Details"
@@ -447,13 +478,14 @@ then
   fct_header "MACHINE CONFIG OPERATOR STATUS"
   fct_title "MCP status"
   ${OC} get machineconfigpool.machineconfiguration.openshift.io | grep -Ev "^$|^No resources|^resource type" | awk '{printf "%s|%s|",$1,$2; if($3 == "UPDATED"){printf "%s|",$3} else if($3 == "True"){printf "G%s|",$3}else{printf "R%s|",$3}; if($4 == "UPDATING"){printf "%s|",$4} else if($4 == "True"){printf "Y%s|",$4}else{printf "G%s|",$4}; if($5 == "DEGRADED"){printf "%s|",$5} else if($5 == "True"){printf "R%s|",$5}else{printf "G%s|",$5}; printf "%s|",$6; if($7 == "READYMACHINECOUNT"){printf "%s|",$7} else if($7 != $6){printf "R%s|",$7}else{printf "G%s|",$7}; if($8 == "UPDATEDMACHINECOUNT"){printf "%s|",$8} else if($8 != $6){printf "Y%s|",$8}else{printf "G%s|",$8}; if($9 == "DEGRADEDMACHINECOUNT"){printf "%s|",$9} else if($9 != 0){printf "Y%s|",$9}else{printf "G%s|",$9}; printf "%s \n",$10}' | column -t -s '|' | sed -e "s/G\([FT]*[a-z0-9]\{1,5\}\\)/${greentext}\1 ${resetcolor}/g" -e "s/Y\([FT]*[0-9a-z]\{1,5\}\\)/${yellowtext}\1 ${resetcolor}/g" -e "s/R\([FT]*[0-9a-z]\{1,5\}\\)/${redtext}\1 ${resetcolor}/g" -e "s/master/${cyantext}&${resetcolor}/" -e "s/worker/${purpletext}&${resetcolor}/" -e "s/infra/${yellowtext}&${resetcolor}/"
-  NODE_DEGRADED=$(${OC} get machineconfigpool.machineconfiguration.openshift.io -o json | grep -Ev "^$|^No resources|^resource type" | jq -r ".items[] | select(.status.conditions[] | (.type == \"NodeDegraded\" and .status == \"True\")) | \"\(.metadata.name)|\(.status.conditions[] | select(.type == \"NodeDegraded\") | .lastTransitionTime)|R-\(.status.conditions[] | select(.type == \"NodeDegraded\") | .reason)-R|Y-\(.status.conditions[] | select(.type == \"NodeDegraded\") | .message[0:${CONDITION_TRUNK}])-Y\"")
-  if [[ ! -z "${NODE_DEGRADED}" ]] && [[ ! -z ${DETAILS} ]]
+  MCP_NODE_DEGRADED=${MCP_NODE_DEGRADED:-$(${OC} get machineconfigpool.machineconfiguration.openshift.io -o json | grep -Ev "^$|^No resources|^resource type" | jq -r --arg trunk ${CONDITION_TRUNK} '.items[] | select(.status.conditions[] | (.type == "NodeDegraded" and .status == "True")) | "\(.metadata.name)|\(.status.conditions[] | select(.type == "NodeDegraded") | .lastTransitionTime)|R-\(.status.conditions[] | select(.type == "NodeDegraded") | .reason)-R|Y-\(.status.conditions[] | select(.type == "NodeDegraded") | .message[0:($trunk|tonumber)] | sub("\n";" "))-Y"')}
+  NODE_JSON=${NODE_JSON:-$(${OC} get nodes -o json | grep -Ev "^$|^No resources|^resource type")}
+  if [[ ! -z "${MCP_NODE_DEGRADED}" ]] && [[ ! -z ${DETAILS} ]]
   then
     fct_title_details "Degraded nodes per MCP - details"
-    echo -e "MCP Name|lastTransitionTime|reason|message\n${NODE_DEGRADED}" | column -t -s'|' | sed -e "s/R-\([0-9a-z \.\-]*\)-R/${redtext}\1    ${resetcolor}/" -e "s/Y-\(.*\)-Y$/${yellowtext}\1 ${resetcolor}/" -e "s/master/${cyantext}&${resetcolor}/" -e "s/worker/${purpletext}&${resetcolor}/" -e "s/infra/${yellowtext}&${resetcolor}/"
+    echo -e "MCP Name|lastTransitionTime|reason|message\n${MCP_NODE_DEGRADED}" | column -t -s'|' | sed -e "s/R-\([0-9a-z \.\-]*\)-R/${redtext}\1    ${resetcolor}/" -e "s/Y-\(.*\)-Y$/${yellowtext}\1 ${resetcolor}/" -e "s/master/${cyantext}&${resetcolor}/" -e "s/worker/${purpletext}&${resetcolor}/" -e "s/infra/${yellowtext}&${resetcolor}/"
   fi
-  PROCESSING_MCP=$(${OC} get machineconfigpool.machineconfiguration.openshift.io -o json | grep -Ev "^$|^No resources|^resource type" | jq -r ".items[] | select(.status.conditions[] | (.type == \"Updated\" and .status == \"False\")) | .metadata.name")
+  PROCESSING_MCP=${PROCESSING_MCP:-$(${OC} get machineconfigpool.machineconfiguration.openshift.io -o json | grep -Ev "^$|^No resources|^resource type" | jq -r '.items[] | select(.status.conditions[] | (.type == "Updated" and .status == "False")) | .metadata.name')}
   if [[ ! -z "${PROCESSING_MCP}" ]] && [[ ! -z ${DETAILS} ]]
   then
     fct_title_details "Processing MCP - machine-config-controller log"
@@ -464,15 +496,15 @@ then
   fct_title "MCP state & versions"
   ${OC} get machineconfigpool.machineconfiguration.openshift.io -o json | grep -Ev "^$|^No resources|^resource type" | jq -r '"MCP Name | Current Rendered | Desired Rendered | Paused | maxUnavailable",(.items[] | "\(.metadata.name) | \(if (.spec.configuration.name != .status.configuration.name) then "RED"+.status.configuration.name else "GREEN"+.status.configuration.name end) | \(.spec.configuration.name) | \(if (.spec.paused != null) then .spec.paused else false end) | \(if (.spec.maxUnavailable != null) then .spec.maxUnavailable else 1 end )")' | column -t -s'|' | sed -e "s/ [1-9]\{1,5\}[0-9][%]*$/${yellowtext}&${resetcolor}/" -e "s/ true /${redtext}&${resetcolor}/" -e "s/master/${cyantext}&${resetcolor}/" -e "s/worker/${purpletext}&${resetcolor}/" -e "s/infra/${yellowtext}&${resetcolor}/" -e "s/RED\([0-9a-z\-]*\)/${redtext}\1   ${resetcolor}/g" -e "s/GREEN\([0-9a-z\-]*\)/${greentext}\1     ${resetcolor}/g"
   fct_title "MCO by node"
-  ${OC} get nodes -o json | grep -Ev "^$|^No resources|^resource type" | jq -r '"Node Name | Current MC | Desired MC | MC State",(.items| sort_by(.metadata.name,.metadata.annotations."machineconfiguration.openshift.io/desiredConfig",.metadata.annotations."machineconfiguration.openshift.io/currentConfig") | .[]  | "\(if (.metadata.annotations."machineconfiguration.openshift.io/currentConfig" == .metadata.annotations."machineconfiguration.openshift.io/desiredConfig") then .metadata.name else "RED"+.metadata.name end) | \(if (.metadata.annotations."machineconfiguration.openshift.io/currentConfig" == .metadata.annotations."machineconfiguration.openshift.io/desiredConfig") then "GREEN" + .metadata.annotations."machineconfiguration.openshift.io/currentConfig" else "RED" + .metadata.annotations."machineconfiguration.openshift.io/currentConfig" end) | \(.metadata.annotations."machineconfiguration.openshift.io/desiredConfig") | \(.metadata.annotations."machineconfiguration.openshift.io/state")")' | column -t -s'|' | sed -e "s/ Degraded$/${redtext}&${resetcolor}/" -e "s/ Done$/${greentext}&${resetcolor}/" -e "s/RED\([0-9a-z\.\-]*\)/${redtext}\1   ${resetcolor}/g" -e "s/GREEN\([0-9a-z\.\-]*\)/${greentext}\1     ${resetcolor}/g"
-  DEGRADED_NODES=$(${OC} get nodes -o json | grep -Ev "^$|^No resources|^resource type" | jq -r '.items | sort_by(.metadata.name) | .[] | select((.metadata.annotations."machineconfiguration.openshift.io/state" == "Degraded") or (.metadata.annotations."machineconfiguration.openshift.io/state" == "Working")) | .metadata.name')
+  echo "${NODE_JSON}" | jq -r '"Node Name | Current MC | Desired MC | MC State",(.items| sort_by(.metadata.name,.metadata.annotations."machineconfiguration.openshift.io/desiredConfig",.metadata.annotations."machineconfiguration.openshift.io/currentConfig") | .[]  | "\(if (.metadata.annotations."machineconfiguration.openshift.io/currentConfig" == .metadata.annotations."machineconfiguration.openshift.io/desiredConfig") then .metadata.name else "RED"+.metadata.name end) | \(if (.metadata.annotations."machineconfiguration.openshift.io/currentConfig" == .metadata.annotations."machineconfiguration.openshift.io/desiredConfig") then "GREEN" + .metadata.annotations."machineconfiguration.openshift.io/currentConfig" else "RED" + .metadata.annotations."machineconfiguration.openshift.io/currentConfig" end) | \(.metadata.annotations."machineconfiguration.openshift.io/desiredConfig") | \(.metadata.annotations."machineconfiguration.openshift.io/state")")' | column -t -s'|' | sed -e "s/ Degraded$/${redtext}&${resetcolor}/" -e "s/ Done$/${greentext}&${resetcolor}/" -e "s/RED\([0-9a-z\.\-]*\)/${redtext}\1   ${resetcolor}/g" -e "s/GREEN\([0-9a-z\.\-]*\)/${greentext}\1     ${resetcolor}/g"
+  DEGRADED_NODES=${DEGRADED_NODES:-$(echo "${NODE_JSON}"  | jq -r '.items | sort_by(.metadata.name) | .[] | select((.metadata.annotations."machineconfiguration.openshift.io/state" == "Degraded") or (.metadata.annotations."machineconfiguration.openshift.io/state" == "Working")) | .metadata.name')}
   if [[ ! -z "${DEGRADED_NODES}" ]] && [[ ! -z ${DETAILS} ]]
   then
     fct_title "Degraded nodes - machine-config-daemon log"
-    MCO_PODS=$(${OC} get pod -n openshift-machine-config-operator -o json | grep -Ev "^$|^No resources|^resource type")
+    MCO_PODS=${MCO_PODS:-$(${OC} get pod -n openshift-machine-config-operator -o json | grep -Ev "^$|^No resources|^resource type")}
     for DEGRADED_NODE in ${DEGRADED_NODES}
     do
-      pod_name=$(echo "${MCO_PODS}" | jq -r ".items[] | select((.spec.nodeName == \"${DEGRADED_NODE}\") and (.metadata.labels.\"k8s-app\" == \"machine-config-daemon\")) | .metadata.name")
+      pod_name=$(echo "${MCO_PODS}" | jq -r --arg degraded_node ${DEGRADED_NODE} '.items[] | select((.spec.nodeName == $degraded_node) and (.metadata.labels."k8s-app" == "machine-config-daemon")) | .metadata.name')
       if [[ ! -z ${pod_name} ]]
       then
         fct_title_details "${DEGRADED_NODE} - ${pod_name} log (last ${TAIL_LOG} lines)"
@@ -487,19 +519,48 @@ if [[ ! -z ${EVENTS} ]] || [[ ! -z ${ALL} ]]
 then
   fct_header "DEFAULT EVENTS"
   fct_title "Events in default namespace"
-  ${OC} get events -n default -o json | grep -Ev "^$|^No resources|^resource type" | jq -r '"creationTimestamp | Name | Reason | Host | Component | Message",(.items | sort_by(.metadata.creationTimestamp) | .[] | "\(.metadata.creationTimestamp) | \(.metadata.name) | \(.reason) | \(.source.host) | \(.source.component) | \(.message)")' | column -t -s'|'
+  ${OC} get events -n default -o json | grep -Ev "^$|^No resources|^resource type" | jq -r '"creationTimestamp | Name | Reason | Host | Component | Message",(.items | sort_by(.metadata.creationTimestamp) | .[] | "\(.metadata.creationTimestamp) | \(.metadata.name) | \(.reason) | \(.source.host) | \(.source.component) | \(.message | sub("\n";" "))")' | column -t -s'|'
 fi
-
+########### SCC ###########
+if [[ ! -z ${SCC} ]] || [[ ! -z ${ALL} ]]
+then
+  fct_header "SCC STATUS"
+  ALL_SCC_JSON=${ALL_SCC_JSON:-$(${OC} get securitycontextconstraints.security.openshift.io -o json | grep -Ev "^$|^No resources|^resource type" | jq -r '. | del(.items[].metadata.annotations)')}
+  if [[ -z ${DETAILS} ]]
+  then
+    fct_title "SCC - overview (Array values truncated)"
+    echo "${ALL_SCC_JSON}" | jq -r '" | | |allowPrivilege| |User & Groups| | | |\nPrioriy|Name|creationTimestamp|Escalation|Container|runAsUser|Users|supplementalGroups|Groups",(.items | sort_by(-(if .priority == null then 0 else .priority end),.metadata.name) |.[] | "\(if (.priority == null) then .priority elif (.priority > 10) then "R_\(.priority)" else "Y_\(.priority)" end)|\(if ((.priority != null) and (.metadata.name != "anyuid")) then "Y_\(.metadata.name)" else "G_\(.metadata.name)" end)|\(.metadata.creationTimestamp)|\(.allowPrivilegeEscalation)|\(.allowPrivilegedContainer)|\(.runAsUser.type)|\(.users[0:1])|\(.supplementalGroups.type)|\(.groups[0:1])")' | column -t -s'|' | sed -e "s/R_\([-a-z0-9]*\)/${redtext}\1  ${resetcolor}/g" -e "s/Y_\([-a-z0-9]*\)/${yellowtext}\1  ${resetcolor}/g" -e "s/G_\([-a-z0-9]*\)/${greentext}\1  ${resetcolor}/g"
+  else
+    fct_title "SCC - overview (full)"
+    echo "${ALL_SCC_JSON}" | jq -r '" | | |allowPrivilege| |User & Groups| | | |\nPrioriy|Name|creationTimestamp|Escalation|Container|runAsUser|Users|supplementalGroups|Groups",(.items | sort_by(-(if .priority == null then 0 else .priority end),.metadata.name) |.[] | "\(if (.priority == null) then .priority elif (.priority > 10) then "R_\(.priority)" else "Y_\(.priority)" end)|\(if ((.priority != null) and (.metadata.name != "anyuid")) then "Y_\(.metadata.name)" else "G_\(.metadata.name)" end)|\(.metadata.creationTimestamp)|\(.allowPrivilegeEscalation)|\(.allowPrivilegedContainer)|\(.runAsUser.type)|\(.users)|\(.supplementalGroups.type)|\(.groups)")' | column -t -s'|' | sed -e "s/R_\([-a-z0-9]*\)/${redtext}\1  ${resetcolor}/g" -e "s/Y_\([-a-z0-9]*\)/${yellowtext}\1  ${resetcolor}/g" -e "s/G_\([-a-z0-9]*\)/${greentext}\1  ${resetcolor}/g"
+    fct_title "SCC - additional Details"
+    echo "${ALL_SCC_JSON}" | jq -r '" | |AllowHost| | | | |Allow| |Restrictions| |SeLinux & Volumes| | | |\nPrioriy|Name|DirVolumePlugin|IPC|Network|PID|Ports|Capabilities|UnsafeSysctls|readOnlyRootFS|requiredDropCAPS|seLinuxContext|seccompProfiles|fsGroup|volumes",(.items | sort_by(-(if .priority == null then 0 else .priority end),.metadata.name) |.[] | "\(if (.priority == null) then .priority elif (.priority > 10) then "R_\(.priority)" else "Y_\(.priority)" end)|\(if ((.priority != null) and (.metadata.name != "anyuid")) then "Y_\(.metadata.name)" else "G_\(.metadata.name)" end)|\(.allowHostDirVolumePlugin)|\(.allowHostIPC)|\(.allowHostNetwork)|\(.allowHostPID)|\(.allowHostPorts)|\(.allowedCapabilities)|\(.allowedUnsafeSysctls)|\(.readOnlyRootFilesystem)|\(.requiredDropCapabilities)|\(.seLinuxContext.type)|\(.seccompProfiles)|\(.fsGroup.type)|\(.volumes)")' | column -t -s'|' | sed -e "s/R_\([-a-z0-9]*\)/${redtext}\1  ${resetcolor}/g" -e "s/Y_\([-a-z0-9]*\)/${yellowtext}\1  ${resetcolor}/g" -e "s/G_\([-a-z0-9]*\)/${greentext}\1  ${resetcolor}/g"
+    POLICIES=$(echo "${ALL_SCC_JSON}" | jq -r '.items | sort_by(-(if .priority == null then 0 else .priority end),.metadata.name) |.[] | select((.priority != null) and (.priority != 0) and (.metadata.name != "anyuid")) | .metadata.name')
+    if [[ ! -z ${POLICIES} ]]
+    then
+      fct_title "SCC - PODs running in high priority SCCs"
+      ALL_PODS_JSON=${ALL_PODS_JSON:-$(${OC} get pod -A -o json | grep -Ev "^$|^No resources|^resource type")}
+      for POLICY in ${POLICIES}
+      do
+        echo "${ALL_PODS_JSON}" | grep -Ev "^$|^No resources|^resource type" | jq -r --arg policy ${POLICY} '.items[] | select((.metadata.annotations."openshift.io/scc" == $policy) and  (.status.phase == "Running")) | .metadata | "\(.namespace)|\(if (.namespace | test("openshift-")) then "R_\(.name)" else .name end)|Y_\(.annotations."openshift.io/scc")|\(.creationTimestamp)"'
+      done | column -t -s'|' | sed -e "s/\(${THIS_month}[-:T0-9]*Z\)$/${yellowtext}\1${resetcolor}/" -e "s/\(${LAST_28days}[-:T0-9]*Z\)$/${yellowtext}\1${resetcolor}/" -e "s/R_\([-a-z0-9]*\)/${redtext}\1  ${resetcolor}/g" -e "s/Y_\([-a-z0-9]*\)/${yellowtext}\1  ${resetcolor}/g" -e "s/G_\([-a-z0-9]*\)/${greentext}\1  ${resetcolor}/g"
+    fi
+  fi
+fi
 ########### PODS ###########
 if [[ ! -z ${PODS} ]] || [[ ! -z ${ALL} ]]
 then
   fct_header "POD STATUS"
-  ALL_PODS_WIDE=$(${OC} get pod -A -o wide | grep -Ev "^$|^No resources|^resource type")
+  ALL_PODS_WIDE=${ALL_PODS_WIDE:-$(${OC} get pod -A -o wide | grep -Ev "^$|^No resources|^resource type")}
   if [[ ! -z ${DETAILS} ]]
   then
-    ALL_PODS=$(${OC} get pod -A | grep -Ev "^$|^No resources|^resource type")
-    ALL_PODS_JSON=$(${OC} get pod -A -o json | grep -Ev "^$|^No resources|^resource type")
+    ALL_PODS=${ALL_PODS:-$(${OC} get pod -A | grep -Ev "^$|^No resources|^resource type")}
+    ALL_PODS_JSON=${ALL_PODS_JSON:-$(${OC} get pod -A -o json | grep -Ev "^$|^No resources|^resource type")}
   fi
+
+  fct_title "PodDisruptionBudget"
+  ${OC} get PodDisruptionBudget.policy -A -o json | grep -Ev "^$|^No resources|^resource type" | jq -r '"Namespace|Name|minAvailable|maxUnavailable|expectedPods|desiredHealthy|currentHealthy|disruptionsAllowed|disruptedPods|selector",(.items | sort_by(.metadata.namespace,.metadata.name) | .[] | "\(.metadata | "\(.namespace)|\(.name)")|\(.spec|"\(.minAvailable)|\(.maxUnavailable)")|\(.status|"\(.expectedPods)|\(.desiredHealthy)|\(if (.currentHealthy < .desiredHealthy) then "R_\(.currentHealthy)" elif (.currentHealthy < .expectedPods) then "Y_\(.currentHealthy)" else "G_\(.currentHealthy)" end)|\(if .disruptionsAllowed == 0 then "Y_\(.disruptionsAllowed)" else "G_\(.disruptionsAllowed)" end)|\(if .disruptedPods != null then "R_\(.disruptedPods)" else "G_\(.disruptedPods)" end)")|\(.spec.selector)")' | column -t -s'|' | sed -e "s/R_\([a-z0-9]*\)/${redtext}\1  ${resetcolor}/g" -e "s/Y_\([a-z0-9]*\)/${yellowtext}\1  ${resetcolor}/g" -e "s/G_\([a-z0-9]*\)/${greentext}\1  ${resetcolor}/g"
+
   fct_title "Unsuccessful PODs"
   echo "${ALL_PODS_WIDE}" | grep -Ev "Running|Completed|Succeeded" | sed -e "s/Terminating/${yellowtext}&${resetcolor}/" -e "s/Pending/${yellowtext}&${resetcolor}/" -e "s/ContainerCreating/${yellowtext}&${resetcolor}/" -e "s/ImagePullBackOff/${yellowtext}&${resetcolor}/" -e "s/PodInitializing/${yellowtext}&${resetcolor}/" -e "s/ErrImagePull/${yellowtext}&${resetcolor}/" -e "s/ Error/${redtext}&${resetcolor}/" -e "s/CrashLoopBackOff/${redtext}&${resetcolor}/" -e "s/Failed/${redtext}&${resetcolor}/" -e "s/CreateContainerError/${redtext}&${resetcolor}/" -e "s/CreateContainerConfigError/${redtext}&${resetcolor}/"
   if [[ ! -z ${DETAILS} ]]
@@ -529,7 +590,7 @@ then
   fct_title "Revision Status"
   for static in etcd kubeapiserver kubecontrollermanager kubescheduler
   do
-    static_revision=$(${OC} get ${static}.operator.openshift.io cluster -o json | grep -Ev "^$|^No resources|^resource type" | jq -r '.status.conditions[] | select(((.type == "NodeInstallerProgressing") or (.type == "APIServerDeploymentProgressing")) and (.message != null)) | ": \(.message)"' | sed -e "s/[0-9] nodes are at revision [0-9]\{1,3\}/${greentext}&${resetcolor}/" -e "s/; \([0-9] nodes are at revision [0-9]\{1,3\}\)/; ${yellowtext}\1${resetcolor}/" -e "s/; \(0 nodes have achieved new revision [0-9]\{1,3\}\)/; ${redtext}\1${resetcolor}/")
+    static_revision=$(${OC} get ${static}.operator.openshift.io cluster -o json | grep -Ev "^$|^No resources|^resource type" | jq -r '.status.conditions[] | select(((.type == "NodeInstallerProgressing") or (.type == "APIServerDeploymentProgressing")) and (.message != null)) | ": \(.message | sub("\n";" "))"' | sed -e "s/[0-9] nodes are at revision [0-9]\{1,3\}/${greentext}&${resetcolor}/" -e "s/; \([0-9] nodes are at revision [0-9]\{1,3\}\)/; ${yellowtext}\1${resetcolor}/" -e "s/; \(0 nodes have achieved new revision [0-9]\{1,3\}\)/; ${redtext}\1${resetcolor}/")
     if [[ ! -z ${static_revision} ]]
     then
       printf "${static}|${static_revision}\n"
@@ -544,12 +605,13 @@ then
       echo "--- Config Maps ---"
       ${OC} get configmap -n ${namespace} -o json | grep -Ev "^$|^No resources|^resource type" | jq -r '.items | sort_by(.metadata.creationTimestamp) | .[] | select(.metadata.name | test("revision-status")) | "\(.metadata.creationTimestamp) | \(.metadata.name) | \(.data.status) | \(.data.reason)"' | column -s '|' -t | tail -5
       echo "--- Installer Pods (up to 10) ---"
-      INSTALLER_DETAILS=$(${OC} get pod -n ${namespace} -l app=installer -o json | grep -Ev "^$|^No resources|^resource type" | jq -r '.items | sort_by(.metadata.creationTimestamp,.metadata.name) | .[] | "\(.metadata.name)|\(.status.containerStatuses[0]|"\(.name)|\(.restartCount)|\(.state | .[] |  "\(.startedAt)|\(.finishedAt)|\(.reason)")")"'| tail -10)
+      ALL_PODS_JSON=${ALL_PODS_JSON:-$(${OC} get pod -A -o json | grep -Ev "^$|^No resources|^resource type")}
+      INSTALLER_DETAILS=$(echo "${ALL_PODS_JSON}" | jq -r --arg namespace ${namespace} '.items | sort_by(.metadata.creationTimestamp,.metadata.name) | .[] | select((.metadata.namespace == $namespace) and (.metadata.labels.app == "installer")) | "\(.metadata.name)|\(.status.containerStatuses[0]|"\(.name)|\(.restartCount)|\(.state | .[] |  "\(.startedAt)|\(.finishedAt)|\(.reason)")")"'| tail -10)
       if [[ -z ${INSTALLER_DETAILS} ]]
       then
         echo "No resources pods.core found in ${namespace} namespace."
       else
-        echo -e "POD Name|Container Name|restartCount|startedAt|finishedAt|reason\n${INSTALLER_DETAILS}" | column -t -s'|'
+        echo -e "POD Name|Container Name|restartCount|startedAt|finishedAt|reason\n${INSTALLER_DETAILS}" | column -t -s'|' | sed -e "s/Completed$/${greentext}&${resetcolor}/" -e "s/Error$/${redtext}&${resetcolor}/"
       fi
       echo
     done
@@ -597,9 +659,9 @@ then
   if [[ ! -z "${RULES}" ]]
   then
     fct_title "firing Alerts"
-    echo ${RULES} | jq -r "\"RULE|STATE|AGE|ALERTS|ACTIVE SINCE\",(if .data != null then (.data[] | select(.state == \"firing\") | \"\(.name)|\(.state)|N/A|\(.alerts | length)|\(\"\(.alerts | sort_by(.activeAt) | .[0].activeAt[0:19])Z\"|fromdate|strftime(\"%d %b %y %H:%M UTC\"))\") else \"\" end)" | column -s'|' -t | sed -e "s/^Kube[a-zA-Z]* /${purpletext}&${resetcolor}/" -e "s/^Cluster[a-zA-Z]* /${purpletext}&${resetcolor}/" -e "s/^System[a-zA-Z]* /${purpletext}&${resetcolor}/" -e "s/ [5-9]  /${yellowtext}&${resetcolor}/" -e "s/ [0-9]\{2,5\}  /${redtext}&${resetcolor}/"
+    echo ${RULES} | jq -r '"RULE|STATE|AGE|ALERTS|ACTIVE SINCE",(if .data != null then (.data[] | select(.state == "firing") | "\(.name)|\(.state)|N/A|\(.alerts | length)|\("\(.alerts | sort_by(.activeAt) | .[0].activeAt[0:19])Z"|fromdate|strftime("%d %b %y %H:%M UTC"))") else "" end)' | column -s'|' -t | sed -e "s/^Kube[a-zA-Z]* /${purpletext}&${resetcolor}/" -e "s/^Cluster[a-zA-Z]* /${purpletext}&${resetcolor}/" -e "s/^System[a-zA-Z]* /${purpletext}&${resetcolor}/" -e "s/ [5-9]  /${yellowtext}&${resetcolor}/" -e "s/ [0-9]\{2,5\}  /${redtext}&${resetcolor}/"
     fct_title "Firing Alerts rules details"
-    echo ${RULES} | jq -r "\"ALERTNAME|LAST ACTIVE|NAMESPACE|WORKLOAD,LABEL,ENDPOINT,JOB,SERVICE OR NODE|SEVERITY|DESCRIPTION|\",if .data != null then (.data[] | select(.state == \"firing\") | .alerts | sort_by(.activeAt) | .[] | \"\(.labels.alertname)|\(.activeAt)|\(.labels.namespace)|\(if (.labels.workload != null) then .labels.workload elif (.labels.pod != null) then .labels.pod elif (.labels.endpoint != null) then .labels.endpoint elif (.labels.job != null) then .labels.job elif (.labels.node != null) then .labels.node else .labels.service end)|\(.labels.severity)|\(if (.annotations.description != null) then .annotations.description[0:${ALERT_TRUNK}] else .annotations.message[0:${ALERT_TRUNK}] end)\") else \"\" end" | column -t -s'|' | sed -e 's/^"//' -e 's/"$//' | sed -e "s/ warning /${yellowtext}&${resetcolor}/" -e "s/ info /${greentext}&${resetcolor}/" -e "s/ critical /${redtext}&${resetcolor}/" -e "s/^Kube[a-zA-Z]* /${purpletext}&${resetcolor}/" -e "s/^Cluster[a-zA-Z]* /${purpletext}&${resetcolor}/" -e "s/^System[a-zA-Z]* /${purpletext}&${resetcolor}/"
+    echo ${RULES} | jq -r --arg trunk ${ALERT_TRUNK} '"ALERTNAME|LAST ACTIVE|NAMESPACE|WORKLOAD,LABEL,ENDPOINT,JOB,SERVICE OR NODE|SEVERITY|DESCRIPTION|",if .data != null then (.data[] | select(.state == "firing") | .alerts | sort_by(.activeAt) | .[] | "\(.labels.alertname)|\(.activeAt)|\(.labels.namespace)|\(if (.labels.workload != null) then .labels.workload elif (.labels.pod != null) then .labels.pod elif (.labels.endpoint != null) then .labels.endpoint elif (.labels.job != null) then .labels.job elif (.labels.node != null) then .labels.node else .labels.service end)|\(.labels.severity)|\(if (.annotations.description != null) then .annotations.description[0:($trunk|tonumber)] | sub("\n";" ") else .annotations.message[0:($trunk|tonumber)] | sub("\n";" ") end)") else "" end' | column -t -s'|' | sed -e 's/^"//' -e 's/"$//' -e "s/ warning /${yellowtext}&${resetcolor}/" -e "s/ info /${greentext}&${resetcolor}/" -e "s/ critical /${redtext}&${resetcolor}/" -e "s/^Kube[a-zA-Z]* /${purpletext}&${resetcolor}/" -e "s/^Cluster[a-zA-Z]* /${purpletext}&${resetcolor}/" -e "s/^System[a-zA-Z]* /${purpletext}&${resetcolor}/"
   else
     ERR_MSG="Failed to retrieve and display the Alerts"
     fct_title "firing Alerts"


### PR DESCRIPTION
- (MAIN) Allowing to replace the colors by setting the variables before running the script (colorblind)
- (README) explaining the new '-d' option for the help
- (SCC) Adding the SecurityContextContraints data in the script
- (POD) Including the PodDisruptionBudget details.
- (MAIN) Avoiding content variables to be query twice.
- (MAIN) Replacing all Shell variables in JQ command by args
- (MAIN) Substituing '\n' characters in jq messages.