### PR TITLE
Version 1.2.15

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,25 @@
 
 --------
 
+## Version 1.2.15
+
+### Minor updates - 1.2.15
+
+- None
+
+### Release updates - 1.2.15
+
+- (NODE) Update the overcommitment details to include the POD count and node pod subnet.
+- (CONTEXT) Include the installation type, based on the methode used in Insights.
+- (CONTEXT) Advise if KeepAlive PODs are running in the cluster, to highlight cluster with VIPs.
+- (POD) Highlight the 'Evicted' status in the 'Unsuccessful PODs' section,
+- (POD) Merging ALL_PODS_WIDE in ALL_PODS to ensure to always have the node name display.
+- (POD) Optimization of the fct_unsuccessful_container_details and fct_restart_container_details functions.
+- (HELP) Explaining the new 'POD_WIDE' variable.
+- (HELP) Flaging the detail option for the help (-h) option.
+
+--------
+
 ## Version 1.2.14
 
 ### Minor updates - 1.2.14

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ usage: mg_cluster_status.sh [-acevMmnopsS] [-d] [-h]
 |         | Additional Options:                                             |           |
 |---------|-----------------------------------------------------------------|-----------|
 |      -d | display additional details on specific Options (as noted above) |           |
-|      -h | display this help and check for updated version                 |           |
+|      -h | display this help and check for updated version                 | [Y]       |
 |---------------------------------------------------------------------------------------|
 
 Customizable variables before running the script (Optional):
@@ -92,8 +92,9 @@ Customizable variables before running the script (Optional):
 |-----------------------------------|----------------------------------------------------------------------------------|------------|-----------|
 |export OC=[omc|omg|oc]             | #Change the must-gather tool (use 'oc' to run the script against live cluster)   | [omc]      |           |
 |export ALERT_TRUNK=<interger>      | #Change the length of the Alert Descriptions                                     | [100]      |           |
-|export CONDITION_TRUNK=<interger   | #Change the length of the Operator Message in 'oc get co'                        | [220]      |           |
-|export POD_TRUNK=<interger         | #Change the length of the POD Message in 'oc get co'                             | [100]      |           |
+|export CONDITION_TRUNK=<interger>  | #Change the length of the Operator Message in 'oc get co'                        | [220]      |           |
+|export POD_TRUNK=<interger>        | #Change the length of the POD Message in 'oc get pod'                            | [100]      |           |
+|export POD_WIDE=<boolean>          | #Enable/Disable the '-o wide' option in the command 'oc get pod'                 | [true]     |           |
 |export MIN_RESTART=<integer>       | #Change the minimal number of restart when checking the POD restarts             | [10]       |           |
 |export TAIL_LOG=<integer>          | #Change the number of lines displayed from logs ('tail')                         | [15]       |           |
 |export graytext=<color_code>       | #Replace the gray color used in the script                                       | [\x1B[30m] |           |


### PR DESCRIPTION
- (NODE) Update the overcommitment details to include the POD count and node pod subnet.
- (CONTEXT) Include the installation type, based on the methode used in Insights.
- (CONTEXT) Advise if KeepAlive PODs are running in the cluster, to highlight cluster with VIPs.
- (POD) Highlight the 'Evicted' status in the 'Unsuccessful PODs' section,
- (POD) Merging ALL_PODS_WIDE in ALL_PODS to ensure to always have the node name display.
- (POD) Optimization of the fct_unsuccessful_container_details and fct_restart_container_details functions.
- (HELP) Explaining the new 'POD_WIDE' variable.
- (HELP) Flaging the detail option for the help (-h) option.