### PR TITLE
Version 1.2.33

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -21,7 +21,7 @@
 ### Release updates - 1.2.33
 
 - (NODE) move the 'kubeletConfig' in the MCO section
-- (MCO) Include 'kubeletConfig' for 'system reserved' and newly '
+- (MCO) Include 'kubeletConfig' for 'system reserved' and newly 'CPU Manager'
 
 --------
 


### PR DESCRIPTION
- (NODE) move the 'kubeletConfig' in the MCO section
- (MCO) Include 'kubeletConfig' for 'system reserved' and newly 'CPU Manager'