### PR TITLE
Version 1.2.48

### DIFF
--- a/mg_cluster_status.sh
+++ b/mg_cluster_status.sh
@@ -934,8 +934,8 @@ then
     MCO_PODS=${MCO_PODS:-$(${OC} get pods -n openshift-machine-config-operator -o json 2>${STD_ERR} | grep -Ev "${MESSAGE_EXCLUSION}")}
     for DEGRADED_NODE in ${DEGRADED_NODES}
     do
-      fct_title_details "${DEGRADED_NODE} - ${pod_name} log (last ${TAIL_LOG} lines)"
       pod_name=$(echo "${MCO_PODS}" | jq -r --arg degraded_node ${DEGRADED_NODE} '.items[] | select((.spec.nodeName == $degraded_node) and (.metadata.labels."k8s-app" == "machine-config-daemon")) | .metadata.name')
+      fct_title_details "${DEGRADED_NODE} - ${pod_name} log (last ${TAIL_LOG} lines)"
       if [[ ! -z ${pod_name} ]]
       then
         if [[ ${OC} == "omc" ]]


### PR DESCRIPTION
- (ETCD) Adding 'lost leader' and 'leader changed' in the ETCD check.
- (MCO) adding a message when the pod log cannot be retrieve for a degraded node.
- (POD) Exclude the header from the sort in the POD restart display.
- (POD) Fix a formatting issue with some POD detail views.
- (CO) only trigger the 'Cluster Operators managementState' when at least one CO has an 'Unknown' condition.
- (CO) Trigger the conditional state displays if the 'Details' are rquested.